### PR TITLE
顧客ユーザーの退会処理の追加と管理者のban機能

### DIFF
--- a/app/assets/stylesheets/admin_users/end_users.scss
+++ b/app/assets/stylesheets/admin_users/end_users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin_users::end_users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/admin_users/home.scss
+++ b/app/assets/stylesheets/admin_users/home.scss
@@ -3,35 +3,20 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 //topアクション画面のcss
-#nav-tab{
-  border: none;
-  line-height: 80px;
-  justify-content: flex-end;
-  &:hover{
-    border: none;
-  }
-}
-#nav-top-tab,#nav-end-user-tab,#nav-quiz-tab{
-  border: none;
-  &:hover{
-    border: none;
-  }
-}
 .admin-top{
   a{
     font: bolder 1.5rem/80px sans-serif;
     margin-right: 50px;
+    padding: 0.5rem 1rem;
     color: #0a77ff;
   }
   a:first-child{
     margin-right: auto;
   }
 }
-#nav-tabContent{
+#admin-content{
   width: 75%;
   margin: 0 auto;
-}
-.tab-pane{
   h2{
     font-weight: bolder;
     color: #9500af;

--- a/app/assets/stylesheets/admin_users/quizes.scss
+++ b/app/assets/stylesheets/admin_users/quizes.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin_users::quizes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/end_users/end_users.scss
+++ b/app/assets/stylesheets/end_users/end_users.scss
@@ -92,19 +92,29 @@
     border-radius: 50%;
   }
 }
-.end_user_name{
+.end-user-name-edit-withdraw{
+  justify-content: flex-end;
+  margin: 10px 0;
+}
+.end-user-name{
   font: bolder 2rem sans-serif;
-  a{
-    position: absolute;
-    right: 50px;
-    padding: 5px;
-    border: solid 1.5px #e6e6e6;
-    border-radius: 15px;
-  }
-  a:hover{
+  margin-right: auto;
+  margin-bottom: 0;
+}
+.edit-profile-button, .end-user-withdraw-button{
+  font: bolder 12px sans-serif;
+  padding: 5px;
+  margin-left: 10px;
+  border: solid 1.5px #e6e6e6;
+  border-radius: 15px;
+  &:hover{
     color: black;
     background-color: #e6e6e6;
   }
+}
+.end-user-withdraw-button:hover{
+  color: red;
+  background-color: #ffcece;
 }
 .profile-sentence{
   font: 1.5rem sans-serif;

--- a/app/controllers/admin_users/end_users_controller.rb
+++ b/app/controllers/admin_users/end_users_controller.rb
@@ -1,0 +1,22 @@
+class AdminUsers::EndUsersController < ApplicationController
+before_action :finished_log_in_as_admin
+
+  def index
+    @end_users = EndUser.where(admin: false)
+  end
+
+  def recover
+    end_user = EndUser.find(params[:id])
+    end_user.update_attribute(:is_available, true)
+    end_user.save
+    redirect_back(fallback_location: root_path)
+  end
+
+  def ban
+    end_user = EndUser.find(params[:id])
+    end_user.update_attribute(:is_available, false)
+    end_user.save
+    redirect_back(fallback_location: root_path)
+  end
+
+end

--- a/app/controllers/admin_users/home_controller.rb
+++ b/app/controllers/admin_users/home_controller.rb
@@ -2,7 +2,6 @@ class AdminUsers::HomeController < ApplicationController
   before_action :logged_in_end_user
 
   def top
-    @end_users = EndUser.where(admin: false)
   end
 
 end

--- a/app/controllers/admin_users/quizes_controller.rb
+++ b/app/controllers/admin_users/quizes_controller.rb
@@ -1,0 +1,6 @@
+class AdminUsers::QuizesController < ApplicationController
+
+  def index
+  end
+
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def finished_log_in_as_admin
+    unless current_end_user.admin?
+      redirect_to root_path
+    end
+  end
+
   def finished_log_in
     if logged_in?
       redirect_to midroom_path

--- a/app/controllers/end_users/end_users_controller.rb
+++ b/app/controllers/end_users/end_users_controller.rb
@@ -1,5 +1,5 @@
 class EndUsers::EndUsersController < ApplicationController
-  before_action :logged_in_end_user, only: [:show, :edit, :update]
+  before_action :logged_in_end_user, only: [:show, :edit, :update, :following, :followers, :withdraw]
   before_action :correct_current_end_user, only: [:edit, :update]
   def new
     @end_user = EndUser.new
@@ -39,6 +39,18 @@ class EndUsers::EndUsersController < ApplicationController
   def followers
     @end_user = EndUser.find(params[:id])
     @follower_end_users = @end_user.followers
+  end
+
+  def withdraw
+    end_user = EndUser.find(params[:id])
+    if end_user == current_end_user
+      end_user.update_attribute(:is_available, false)
+      end_user.save
+      log_out if logged_in?
+      redirect_to root_path
+    else
+      redirect_back(fallback_location: root_path)
+    end
   end
 
   private

--- a/app/controllers/end_users/sessions_controller.rb
+++ b/app/controllers/end_users/sessions_controller.rb
@@ -5,9 +5,14 @@ class EndUsers::SessionsController < ApplicationController
   def create
     end_user = EndUser.find_by(name: params[:session][:name])
     if end_user && end_user.authenticate(params[:session][:password])
-      log_in end_user
-      params[:session][:remember_me] == '1'? remember(end_user) : forget(end_user)
-      redirect_to quizes_path
+      if end_user.is_available
+        log_in end_user
+        params[:session][:remember_me] == '1'? remember(end_user) : forget(end_user)
+        redirect_to quizes_path
+      else
+        flash.now[:danger] = "退会済みもしくは運営によってbanされたユーザーです"
+        render 'new'
+      end
     else
       flash.now[:danger] = "ユーザー名またはパスワードが正しくありません。"
       render 'new'

--- a/app/helpers/admin_users/end_users_helper.rb
+++ b/app/helpers/admin_users/end_users_helper.rb
@@ -1,0 +1,2 @@
+module AdminUsers::EndUsersHelper
+end

--- a/app/helpers/admin_users/quizes_helper.rb
+++ b/app/helpers/admin_users/quizes_helper.rb
@@ -1,0 +1,2 @@
+module AdminUsers::QuizesHelper
+end

--- a/app/views/admin_users/end_users/index.html.erb
+++ b/app/views/admin_users/end_users/index.html.erb
@@ -1,0 +1,44 @@
+<%= render '/shared/header' %>
+<div id="admin-content">
+  <h2>利用者一覧</h2>
+  <table class="table table-hover">
+    <thead>
+      <tr class="end-user-table-head">
+        <th scope="col">ユーザー名</th>
+        <th scope="col">メールアドレス</th>
+        <th scope="col">クイズスコア</th>
+        <th scope="col">退会ステータス</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @end_users.each do |end_user| %>
+      　<tr class="end-user-record">
+          <td><%= end_user.name %></td>
+          <td><%= end_user.email %></td>
+          <td>
+            <% if end_user.quiz_score %>
+              <%= end_user.quiz_score %>
+            <% else %>
+              未回答
+            <% end %>
+          </td>
+          <% if end_user.is_available %>
+            <td class="dropdown">
+              <a href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span style="color: lightgreen;">有効</span></a>
+              <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                <a href="/admin_users/ban/<%= end_user.id %>" data-method="post">無効にする</a>
+              </div>
+            </td>
+          <% else %>
+           <td class="dropdown">
+              <a href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span style="color: red;">無効</span></a>
+              <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                <a href="/admin_users/recover/<%= end_user.id %>" data-method="post">有効にする</a>
+              </div>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin_users/home/top.html.erb
+++ b/app/views/admin_users/home/top.html.erb
@@ -1,1 +1,5 @@
 <%= render '/shared/header' %>
+<div id="admin-content">
+  <h2>ここは管理者トップ画面です</h2>
+  <p style="font: bolder 1.6rem sans-serif;">画面上部にあるヘッダーから希望のアクションを選択してください。</p>
+</div>

--- a/app/views/admin_users/quizes/index.html.erb
+++ b/app/views/admin_users/quizes/index.html.erb
@@ -1,0 +1,4 @@
+<%= render '/shared/header' %>
+<div id="admin-content">
+  <h2>クイズ管理</h2>
+</div>

--- a/app/views/end_users/end_users/show.html.erb
+++ b/app/views/end_users/end_users/show.html.erb
@@ -6,12 +6,13 @@
     <% else %>
       <div class="profile-image"><img src="/assets/no_image.jpg"></div>
     <% end %>
-    <p class="end_user_name">
-      <%= @end_user.name %>
+    <div class="end-user-name-edit-withdraw flex">
+      <p class="end-user-name"><%= @end_user.name %></p>
       <% if @end_user.id == current_end_user.id %>
-        <%= link_to 'プロフィールを編集', edit_end_user_path(@end_user) %>
+        <%= link_to 'プロフィールを編集', edit_end_user_path(@end_user), class: "edit-profile-button" %>
+        <%= link_to 'アカウント削除', withdraw_end_user_path(@end_user), method: :post, data: {confirm: "【確認】アカウントを削除しますか？\n(再度このアカウントでログインすることはできなくなります)"}, class: "end-user-withdraw-button" %>
       <% end %>
-    </p>
+    </div>
     <%= render '/shared/follow_stats.html.erb' %>
     <p class="profile-sentence"><%= @end_user.profile %></p>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,51 +1,14 @@
 <% if logged_in? %>
   <% if current_end_user.admin? %>
     <nav class="admin-top">
-      <div class="nav nav-tabs" id="nav-tab" role="tablist">
-        <a class="nav-item nav-link active" id="nav-top-tab" data-toggle="tab" href="#nav-top" role="tab" aria-controls="nav-top" aria-selected="true"><img src="/assets/logo_transparent.png" alt="ロゴ" style="width: 22rem; height: 6.5rem; margin: 0.75rem 0 0 3%;"></a>
-        <a class="nav-item nav-link" id="nav-end-user-tab" data-toggle="tab" href="#nav-end-user" role="tab" aria-controls="nav-end-user" aria-selected="false">利用者の一覧</a>
-        <a class="nav-item nav-link" id="nav-quiz-tab" data-toggle="tab" href="#nav-quiz" role="tab" aria-controls="nav-quiz" aria-selected="false">クイズ管理</a>
-        <a data-confirm="本当にログアウトしますか？" rel="nofollow" data-method="delete" href="/logout" style="color: #ff4f4f; display: block; padding: 0.5rem 1rem;">ログアウト</a>
+      <div class="flex">
+        <a href="/admin_users"><img src="/assets/logo_transparent.png" alt="ロゴ" style="width: 22rem; height: 6.5rem; margin: 0.75rem 0 0 3%;"></a>
+        <a href="/admin_users/end_users">利用者の一覧</a>
+        <a href="/admin_users/quizes">クイズ管理</a>
+        <a data-confirm="本当にログアウトしますか？" data-method="delete" href="/logout" style="color: #ff4f4f; display: block; padding: 0.5rem 1rem;">ログアウト</a>
       </div>
     </nav>
-    <div class="tab-content" id="nav-tabContent">
-      <div class="tab-pane fade show active" id="nav-top" role="tabpanel" aria-labelledby="nav-top-tab">
-        <h2>ここは管理者トップ画面です</h2>
-        <p style="font: bolder 1.6rem sans-serif;">画面上部にあるヘッダーから希望のアクションを選択してください。</p>
-      </div>
-      <div class="tab-pane fade" id="nav-end-user" role="tabpanel" aria-labelledby="nav-end-user-tab">
-        <h2>利用者一覧</h2>
-        <table class="table table-hover">
-          <thead>
-            <tr class="end-user-table-head">
-              <th scope="col">ユーザー名</th>
-              <th scope="col">メールアドレス</th>
-              <th scope="col">クイズスコア</th>
-              <th scope="col">退会ステータス</th>
-            </tr>
-          </thead>
-          <tbody>
-          　<% @end_users.each do |end_user| %>
-            　<tr class="end-user-record">
-                <td><%= end_user.name %></td>
-                <td><%= end_user.email %></td>
-                <td>
-                  <% if end_user.quiz_score %>
-                    <%= end_user.quiz_score %>
-                  <% else %>
-                    未回答
-                  <% end %>
-                </td>
-                <td style="color: lightgreen;">有効</td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      </div>
-      <div class="tab-pane fade" id="nav-quiz" role="tabpanel" aria-labelledby="nav-quiz-tab">
-        <h2>クイズ管理</h2>
-      </div>
-    </div>
+
   <% else %>
     <header class="flex logo-left">
       <img src="/assets/logo_transparent.png" alt="ロゴ">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     resources :end_users do
       member do
         get :following, :followers
+        post :withdraw
       end
     end
     resources :posts, only: [:create, :show, :edit, :update, :destroy] do
@@ -25,5 +26,8 @@ Rails.application.routes.draw do
   namespace :admin_users do
     get '/', to: 'home#top'
     resources :quizes, only: [:index, :create, :destroy]
+    resources :end_users, only: [:index]
+    post '/recover/:id', to: 'end_users#recover'
+    post '/ban/:id', to: 'end_users#ban'
   end
 end

--- a/db/migrate/20210910123232_add_is_available_to_end_user.rb
+++ b/db/migrate/20210910123232_add_is_available_to_end_user.rb
@@ -1,0 +1,5 @@
+class AddIsAvailableToEndUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :end_users, :is_available, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_07_004944) do
+ActiveRecord::Schema.define(version: 2021_09_10_123232) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 2021_09_07_004944) do
     t.integer "quiz_score"
     t.string "profile"
     t.boolean "admin", default: false
+    t.boolean "is_available", default: true
     t.index ["email"], name: "index_end_users_on_email", unique: true
     t.index ["name"], name: "index_end_users_on_name", unique: true
   end

--- a/test/controllers/admin_users/end_users_controller_test.rb
+++ b/test/controllers/admin_users/end_users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AdminUsers::EndUsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/admin_users/quizes_controller_test.rb
+++ b/test/controllers/admin_users/quizes_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AdminUsers::QuizesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
まず管理者のヘッダーなのですが、Bootstrapで実装されていた部分を通常のリンクに変えました。
理由：リダイレクトすると毎回トップ画面に戻ってしまうため。（クッキーでタブメニューの保持をする方法もあるようでしたが、勉強不足で記事を見ても理解して実装できなかったため、今回のような形を取りました）
よろしくお願いします。