### PR TITLE
フォロー機能関連修正完了

### DIFF
--- a/app/assets/stylesheets/end_users/end_users.scss
+++ b/app/assets/stylesheets/end_users/end_users.scss
@@ -124,13 +124,6 @@
     font: bolder 2rem sans-serif;
     margin-right: 15px;
   }
-  // p:last-child{
-  //   padding: 0 15px;
-  //   position: absolute;
-  //   right: 8%;
-  //   background-color: #e6e6e6;
-  //   border-radius: 15px;
-  // }
   span{
     opacity: .5;
     font-size: 1.3rem;
@@ -173,6 +166,13 @@
     background-color: #86c7ff;
     box-shadow: 0px 0px 4px #86c7ff;
   }
+  .no-level{
+    background-color: #e6e6e6;
+    box-shadow: 0px 0px 3px #e6e6e6;
+  }
+}
+#end-user-follow-rel-button-show{
+  margin-top: 0;
 }
 //以下エンドユーザーのedit画面のcss
 

--- a/app/controllers/end_users/end_users_controller.rb
+++ b/app/controllers/end_users/end_users_controller.rb
@@ -42,12 +42,13 @@ class EndUsers::EndUsersController < ApplicationController
 
   def following
     @end_user = EndUser.find(params[:id])
-    @following_end_users = @end_user.following
+    @following_end_users = @end_user.active_relationships.order(:relationship, id: "DESC").map{|relationship| relationship.followed}
+
   end
 
   def followers
     @end_user = EndUser.find(params[:id])
-    @follower_end_users = @end_user.followers
+    @follower_end_users = @end_user.passive_relationships.order(:relationship, id: "DESC").map{|relationship| relationship.follower}
   end
 
   def withdraw

--- a/app/views/end_users/end_users/_follow.html.erb
+++ b/app/views/end_users/end_users/_follow.html.erb
@@ -1,4 +1,4 @@
 <%= form_with(model: current_end_user.active_relationships.build, remote: true) do |f| %>
   <%= f.hidden_field :followed_id, :value => end_user.id %>
-  <%= f.submit "フォロー", class: "follow-rel-button" %>
+  <%= f.submit "フォロー", class: "follow-rel-button", id: "end-user-follow-rel-button-show" %>
 <% end %>

--- a/app/views/end_users/end_users/_unfollow.html.erb
+++ b/app/views/end_users/end_users/_unfollow.html.erb
@@ -1,3 +1,3 @@
 <%= form_with(model: current_end_user.active_relationships.find_by(followed_id: end_user.id), html: {method: :delete}, remote: true) do |f| %>
-  <%= f.submit "フォロー解除", class: "follow-rel-button" %>
+  <%= f.submit "フォロー解除", class: "follow-rel-button unfollow-button", id: "end-user-follow-rel-button-show" %>
 <% end %>

--- a/app/views/end_users/end_users/show.html.erb
+++ b/app/views/end_users/end_users/show.html.erb
@@ -23,6 +23,10 @@
           <span class="upper-level">Upper</span>
         <% end %>
       </div>
+    <% else %>
+      <div class="end-user-room-level">
+        <span class="no-level">No-Level</span>
+      </div>
     <% end %>
     <%= render '/shared/follow_stats.html.erb' %>
     <p class="profile-sentence"><%= @end_user.profile %></p>


### PR DESCRIPTION
修正点
・フォロー、フォロ解除ボタンの位置の修正
・フォロー一覧とフォロワー一覧が、今まではend_userのid順になっていたが、relationshipのidの降順に基づいて陳列するようにした。